### PR TITLE
Fix tooltip updating on item use

### DIFF
--- a/Assets/Scripts/UI/ShortcutButton.cs
+++ b/Assets/Scripts/UI/ShortcutButton.cs
@@ -89,7 +89,7 @@ namespace TouhouPrideGameJam4.UI
             }
             Content = item;
             _contentImage.sprite = item != null ? item.Sprite : null;
-            _contentImage.color = item == null ? new Color(0f, 0f, 0f, 0f) : Color.white; 
+            _contentImage.color = item == null ? new Color(0f, 0f, 0f, 0f) : Color.white;
         }
 
         public void OnPointerExit(PointerEventData eventData)


### PR DESCRIPTION
When you put your cursor on a item to see its
description, then use the item, it will now update
the tooltip.